### PR TITLE
Improve app release documentation

### DIFF
--- a/processes/app_release.md
+++ b/processes/app_release.md
@@ -1,48 +1,47 @@
 ## App release commands
-
----
-### Below you will find step by step how to do a release for groupware apps
-
+#### Below you will find step by step how to do a release for groupware apps
+## Preparation 
 1. Change directory to the app directory and make sure your environment is clean with `git status`
+2. Check if you have the remote release by running `git remote -v` if that points to `git@github.com:nextcloud-releases/AppName.git`, you're good
+3. If you don't see that in the list, do `git remote add release git@github.com:nextcloud-releases/AppName.git`
+## Process of the release
+4. For patch release do `git checkout stablex.x` (the latest stable version you have) or master/main for major/minor release (this is the branch we want to release)
 
-2. For patch release do `git checkout stablex.x` (the latest stable version you have) or master/main for major/minor release (this is the branch we want to release)
+5. `git pull` to have the latest changes
 
-3. `git pull` to have the latest changes
+6. `git log v1.2.3..HEAD --oneline` - this shows all the commits from version v1.2.3 (last release) to HEAD (latest unreleased commit)
 
-4. `git log v1.2.3..HEAD --oneline` - this shows all the commits from version v1.2.3 (last release) to HEAD (latest unreleased commit)
+    6.1 To ignore the "Merge .." commit you do `git log v1.2.3..HEAD --oneline | grep -v "Merge "`
 
-    4.1 To ignore the "Merge .." commit you do `git log v1.2.3..HEAD --oneline | grep -v "Merge "`
+7. The commits will be shown, and then we can create a change log with the commits that are shown.
 
-5. The commits will be shown, and then we can create a change log with the commits that are shown.
+8. We change the version on `info.xml`, `package.json` and `package-lock.json`
 
-6. We change the version on `info.xml`, `package.json` and `package-lock.json`
+    8.1 Tip - Expected number of changed files is 4
 
-    6.1 Tip - Expected number of changed files is 4
+9. `git checkout -b release/x.x.x` to create the release branch
 
-7. `git checkout -b release/x.x.x` to create the release branch
+10. `git add`, `git commit` (add the version as message) and then we can
 
-8. `git add`, `git commit` (add the version as message) and then we can
+11. `git push origin release/x.x.x` and open a new PR against the target branch (stablex.xx or master/main)
 
-9. `git push origin release/x.x.x` and open a new PR against the target branch (stablex.xx or master/main)
+12. Once merged, switch back to the target branch and `git pull` the latest changes
 
-10. Once merged, switch back to the target branch and `git pull` the latest changes
+13. `git tag vx.x.x`
 
-11. `git tag vx.x.x`
+14. `git push origin stablex.x --tags` (this means we push the commit + tags)
+15. Run `git push release stablex.x --tags` to push it also to the release remote
+16. If the case is a minor or major version, you need to branch off this minor or major release: `git checkout -b  stablex.x` then do `git push origin stablex.x`
 
-12. `git push origin stablex.x --tags` (this means we push the commit + tags)
+17. We go to the release's repository tags page, e.g. https://github.com/nextcloud-releases/mail/tags
 
-13. We should also push it to the release `git push release stablex.x --tags`
+    17.1 On the draft we add the tag we created, add the change log and publish the release
 
-14. Then we go to the release's repository tags page, e.g. https://github.com/nextcloud-releases/mail/tags
-
-    14.1 On this draft we add the tag we created, add the change log and publish the release
-
-    14.2 Wait a few minutes for the automation to build the app
+    17.2 Wait a few minutes for the automation to build the app
     
-    16.3 The package will be atuomatically built and attached to the new release
+    17.3 The package will be automatically built and attached to the new release
 
-15. Open the app's main repo and close the vx.y.z milestone (Issues -> Milestones in the Right Upper Corner)
-
-16. Create a milestone for the next patch version
-
-17. If the release was for patch version, forward-port the changelog to master/main (`git checkout stablex.x CHANGELOG.md`)
+18. Open the app's main repo and close the vx.y.z milestone (Issues -> Milestones in the Right Upper Corner)
+19. Create a milestone for the next patch/major/minor version
+20. After branch off, you need to create a new separate PR against main to change the `info.xml` version to x.x.0-alpha.1, so add the suffix `-alpha.1` to your branch off release version
+21. If the release was for patch version, forward-port the changelog to master/main (`git checkout stablex.x CHANGELOG.md`)


### PR DESCRIPTION
1. git release remote has to be set up
2. document when to branch into stable branches
3. document when to bump the main version